### PR TITLE
useQueryString Hook

### DIFF
--- a/hooks/useQueryString.tsx
+++ b/hooks/useQueryString.tsx
@@ -1,0 +1,84 @@
+import queryString from 'query-string';
+import { useCallback, useRef } from 'react';
+import {
+  ParamKeyValuePair,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom';
+import { shallowEqual } from 'fast-equals';
+
+export const useQueryString = <T, U = { [K in keyof T]: string }>(): {
+  queryString: U;
+  navigateQueryString: (obj: U) => void;
+  deleteQueryString: (obj: string[]) => void;
+  navigateSendData: (obj: U) => void;
+} => {
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const _queryString = queryString.parse(search);
+  const prevQueryString = useRef<U>();
+
+  const isEqual = shallowEqual(_queryString, prevQueryString.current);
+  if (!prevQueryString.current || !isEqual) {
+    prevQueryString.current = _queryString as U;
+  }
+
+  const navigateQs = useCallback(
+    (obj: U) => {
+      const defaultQs = queryString.parse(search);
+
+      setSearchParams({
+        ...defaultQs,
+        ...(obj as ParamKeyValuePair[]),
+      });
+    },
+    [search, setSearchParams]
+  );
+
+  const deleteQs = useCallback(
+    (obj: string[]) => {
+      const excludeQs = queryString.exclude(window.location.href, obj);
+      const splitExcludeQsByQuestionMark = excludeQs.split('?');
+      const getOnlyQueryStringFromExcludeQs =
+        splitExcludeQsByQuestionMark.length > 1
+          ? `?${splitExcludeQsByQuestionMark[1]}`
+          : null;
+      const parsingExcludeQs = getOnlyQueryStringFromExcludeQs
+        ? queryString.parse(getOnlyQueryStringFromExcludeQs)
+        : {};
+
+      setSearchParams({
+        ...parsingExcludeQs,
+        ...({} as ParamKeyValuePair[]),
+      });
+    },
+    [search]
+  );
+
+  const navigateData = useCallback(
+    (obj: U) => {
+      const defaultUrl = `${pathname}${search}`;
+
+      navigate(defaultUrl, {
+        state: obj,
+      });
+    },
+    [navigate, pathname, search]
+  );
+
+  return {
+    queryString: prevQueryString.current,
+    navigateQueryString: (obj: U) => {
+      navigateQs(obj);
+    },
+    deleteQueryString: (obj: string[]) => {
+      deleteQs(obj);
+    },
+    navigateSendData: (obj: U) => {
+      navigateData(obj);
+    },
+  };
+};


### PR DESCRIPTION
한 페이지 내에서 URL 제어를 통한 요소 제어를 위해 만든 React Custom Hook입니다.

**props 설명**
- General Type
- key - value string 타입 형식으로 넘겨줄 수 있으며, 자동으로 쿼리스트링 형태로 URL에 삽입됩니다.

**export 항목 설명**
queryString : 현재 URL의 쿼리스트링을 key - value 형태로 반환합니다
navigateQueryString : 원하는 쿼리스트링을 넘겨 해당 쿼리스트링을 URL에 삽입합니다
deleteQueryString : 삭제하고자 하는 key-value 값을 넣어 쿼리스트링에서 해당 값만 제거합니다
navigateSendData : URL에 표시하고 싶지 않은 데이터를 넘겨주는데 사용합니다. useNavigate의 state객체를 사용합니다

**한계점**
쿼리스트링과 URL 제어에 대한 고민을 많이 했던 커스텀 훅이었습니다.
다만, Next.js App Router를 경험한 후, 프레임워크의 대단함에 대해 다시 한 번 경험할 수 있는 발판이 된 커스텀 훅입니다.